### PR TITLE
Git Pull

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -14,7 +14,7 @@ var Cmd = &Z.Cmd{
 
 	Name:      `zet`,
 	Summary:   `zettelkasten commander`,
-	Version:   `v0.0.6`,
+	Version:   `v0.0.7`,
 	Copyright: `Copyright 2022 Daniel Michaels`,
 	License:   `Apache-2.0`,
 	Site:      `danielms.site`,
@@ -26,7 +26,7 @@ var Cmd = &Z.Cmd{
 		help.Cmd, conf.Cmd, vars.Cmd,
 
 		// local commands (in this module)
-		CreateCmd, LastCmd, EditCmd, GetCmd, QueryCmd, FindCmd, CheckCmd, TagsCmd,
+		CreateCmd, LastCmd, EditCmd, GetCmd, QueryCmd, FindCmd, CheckCmd, TagsCmd, GitCmd,
 	},
 	Description: `
 		The **{{.Name}}** command is Zettelkasten Bonzai branch used to create

--- a/git.go
+++ b/git.go
@@ -4,10 +4,37 @@ import (
 	"errors"
 	"fmt"
 	Z "github.com/rwxrob/bonzai/z"
+	"github.com/rwxrob/help"
 	"os"
 	"path/filepath"
 	"strings"
 )
+
+var GitCmd = &Z.Cmd{
+	Name:     `git`,
+	Summary:  `run git commands over the zet repo`,
+	MinArgs:  1,
+	Usage:    `must provide a git command`,
+	Commands: []*Z.Cmd{help.Cmd, gitPull},
+}
+
+var gitPull = &Z.Cmd{
+	Name:     `pull`,
+	Summary:  `retrieve upstream latest commits`,
+	Commands: []*Z.Cmd{help.Cmd},
+	Call: func(caller *Z.Cmd, args ...string) error {
+		z := new(Zet)
+		err := z.ChangeDir(z.GetRepo())
+		if err != nil {
+			return err
+		}
+		err = Z.Exec("git", "pull")
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+}
 
 // scanAndCommit checks that the user wants to commit their work to the VCS
 // and pushes the commit if they accept.


### PR DESCRIPTION
This adds a new command `git` and the `pull` subcommand.

Calling `zet git pull` will sync upstream with the local zet repo.

closes: #10