### PR TITLE
Fix broken create

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -14,7 +14,7 @@ var Cmd = &Z.Cmd{
 
 	Name:      `zet`,
 	Summary:   `zettelkasten commander`,
-	Version:   `v0.0.8`,
+	Version:   `v0.0.9`,
 	Copyright: `Copyright 2022 Daniel Michaels`,
 	License:   `Apache-2.0`,
 	Site:      `danielms.site`,

--- a/git.go
+++ b/git.go
@@ -6,7 +6,6 @@ import (
 	Z "github.com/rwxrob/bonzai/z"
 	"github.com/rwxrob/help"
 	"os"
-	"path/filepath"
 	"strings"
 )
 
@@ -56,7 +55,6 @@ func (z *Zet) scanAndCommit(zet string) error {
 		fmt.Printf("%q not commited but modified\n", zet)
 		return nil
 	}
-	z.Path = filepath.Join(z.GetRepo(), zet)
 	err = z.PullAddCommitPush()
 	if err != nil {
 		return err
@@ -67,11 +65,13 @@ func (z *Zet) scanAndCommit(zet string) error {
 // PullAddCommitPush is a helper method which flows through a Git workflow
 // and is called often in Commands such as `create` and `edit`.
 func (z *Zet) PullAddCommitPush() error {
-	err := z.GetTitle()
-	if err != nil {
-		return err
+	if z.Title == "" {
+		err := z.GetTitle()
+		if err != nil {
+			return err
+		}
 	}
-	err = z.Pull()
+	err := z.Pull()
 	if err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func (z *Zet) Pull() error {
 	if err != nil {
 		return err
 	}
-	err = z.ChangeDir(z.Path)
+	err = z.ChangeDir(ZetRepo)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func (z *Zet) Pull() error {
 }
 
 func (z *Zet) Add() error {
-	err := z.ChangeDir(z.Path)
+	err := z.ChangeDir(ZetRepo)
 	if err != nil {
 		return err
 	}
@@ -131,7 +131,7 @@ func (z *Zet) Add() error {
 }
 
 func (z *Zet) Commit() error {
-	err := z.ChangeDir(z.Path)
+	err := z.ChangeDir(ZetRepo)
 	if err != nil {
 		return err
 	}
@@ -148,7 +148,7 @@ func (z *Zet) Push() error {
 	if err != nil {
 		return err
 	}
-	err = z.ChangeDir(z.Path)
+	err = z.ChangeDir(ZetRepo)
 	if err != nil {
 		return err
 	}

--- a/zet.go
+++ b/zet.go
@@ -29,6 +29,7 @@ var (
 	GitBranch   = "main"
 	RepoName    = "zet"
 	GitRepo     = filepath.Join(os.Getenv("HOME"), os.Getenv("REPOS"))
+	ZetRepo     = filepath.Join(GitRepo, RepoName)
 	Pictures    = filepath.Join(os.Getenv("HOME"), "Pictures", "zet")
 	Screenshots = filepath.Join(os.Getenv("HOME"), "Pictures", "zet")
 	Downloads   = filepath.Join(os.Getenv("HOME"), "Downloads")
@@ -378,7 +379,7 @@ type Zet struct {
 }
 
 // GetRepo returns the GitRepo and RepoName as a filepath.
-func (z *Zet) GetRepo() string { return filepath.Join(GitRepo, RepoName) }
+func (z *Zet) GetRepo() string { return ZetRepo }
 
 // GetReadme returns a filepath with README.md appended using a filepath join. This
 // is used to retrieve the full path to the README.md being written to or read from.


### PR DESCRIPTION
The create command was incorrectly creating a double up on the path resulting in failing git commands.