### PR TITLE
Fix zet edit bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ go install github.com/danielmichaels/zet-cmd/cmd/zet@latest
 Composed
 
 ```go
-package z
+package zet
 
 import (
 	Z "github.com/rwxrob/bonzai/z"
@@ -24,7 +24,7 @@ import (
 )
 
 var Cmd = &Z.Cmd{
-	Name:     `z`,
+	Name:     `zet`,
 	Commands: []*Z.Cmd{help.Cmd, zet.Cmd},
 }
 ```
@@ -41,12 +41,7 @@ On a new machine (but existing `zet` repo), you will need to `git clone` to the 
 
 - `EDITOR` must be set to create and edit Zet's.
 - `GITUSER` must be your GitHub account username
-- `REPOS` should point to location of your code repos. e.g. `$HOME/Code/github`. Without this `zet` cannot find the directory or files
-
-The `REPOS` environment variable is important as it is used to find the directory of your `zet` 
-repository. It is the `zet` repo which stores all the commits - see the note to identify if the 
-directory paths and environment variables are set correctly before attempting to `zet create` or 
-`edit`.
+- `ZETDIR` should point to the `zet` repo on your system e.g. `$HOME/Code/github/zet`. Without this `zet` cannot find the directory or files
 
 **📣 Note**
 

--- a/cmd.go
+++ b/cmd.go
@@ -14,7 +14,7 @@ var Cmd = &Z.Cmd{
 
 	Name:      `zet`,
 	Summary:   `zettelkasten commander`,
-	Version:   `v0.0.9`,
+	Version:   `v0.1.0`,
 	Copyright: `Copyright 2022 Daniel Michaels`,
 	License:   `Apache-2.0`,
 	Site:      `danielms.site`,

--- a/edit.go
+++ b/edit.go
@@ -94,7 +94,7 @@ var findEdit = &Z.Cmd{
 	Call: func(caller *Z.Cmd, args ...string) error {
 		z := new(Zet)
 
-		err := z.ChangeDir(z.GetRepo())
+		err := z.ChangeDir(ZetRepo)
 		if err != nil {
 			return err
 		}
@@ -144,13 +144,15 @@ var findEdit = &Z.Cmd{
 
 		var zet string
 		for _, k := range ff {
-			idx := k.Index
-			if s != idx {
-				fmt.Println("Key entered does not match, or zet could not be found")
-				return nil
+			if s == k.Index {
+				zet = k.Id
 			}
-			zet = k.Id
 		}
+		if zet == "" {
+			fmt.Println("Key entered does not match, or zet could not be found")
+			return nil
+		}
+
 		err = z.editZet(zet)
 		if err != nil {
 			return err

--- a/git.go
+++ b/git.go
@@ -68,7 +68,7 @@ func (z *Zet) PullAddCommitPush() error {
 	if z.Title == "" {
 		err := z.GetTitle()
 		if err != nil {
-			return err
+			return errors.New("failed to ascertain zet title")
 		}
 	}
 	err := z.Pull()

--- a/zet.go
+++ b/zet.go
@@ -26,10 +26,8 @@ var (
 	Pager       = os.Getenv("PAGER")
 	Editor      = os.Getenv("EDITOR")
 	GitUser     = os.Getenv("GITUSER")
-	GitBranch   = "main"
 	RepoName    = "zet"
-	GitRepo     = filepath.Join(os.Getenv("HOME"), os.Getenv("REPOS"))
-	ZetRepo     = filepath.Join(GitRepo, RepoName)
+	ZetRepo     = filepath.Join(os.Getenv("ZETDIR"))
 	Pictures    = filepath.Join(os.Getenv("HOME"), "Pictures", "zet")
 	Screenshots = filepath.Join(os.Getenv("HOME"), "Pictures", "zet")
 	Downloads   = filepath.Join(os.Getenv("HOME"), "Downloads")
@@ -487,7 +485,7 @@ func (z *Zet) ReadDir(path string) ([]string, error) {
 // CreateDir creates a directory inside the zet repository using the Isosec
 // function to create the directory using the returned timestamp.
 func (z *Zet) CreateDir() (string, error) {
-	path := filepath.Join(GitRepo, RepoName, Isosec())
+	path := filepath.Join(ZetRepo, Isosec())
 	err := mkdir(path)
 	if err != nil {
 		return "", err
@@ -526,6 +524,8 @@ func (z *Zet) Last() (string, error) {
 			last = f.Name()
 		}
 	}
+	// Set path on Zet now as its used everywhere
+	z.Path = filepath.Join(ZetRepo, last)
 	return last, nil
 }
 
@@ -547,7 +547,7 @@ func (z *Zet) CheckZetConfig() error {
 	}
 	fmt.Println(term.Blue + "Repos Variable: " + term.Reset + REPOS)
 	fmt.Println(term.Blue + "GitUser: " + term.Reset + GitUser)
-	fmt.Println(term.Blue + "GitRepo: " + term.Reset + GitRepo)
+	fmt.Println(term.Blue + "ZetRepo: " + term.Reset + ZetRepo)
 	fmt.Println(term.Blue + "System Zet Repo: " + term.Reset + z.GetRepo())
 	// Future use case info
 	fmt.Println(term.U + term.Yellow + "Utility Directories" + term.Reset)


### PR DESCRIPTION
Remove `REPOS` and replace with `ZETDIR` environment variable. This way a user must set the explicit path to the zet directory preventing file join issues.

