### PR TITLE
`zet edit <tgt>` prompt and bug fixes

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -14,7 +14,7 @@ var Cmd = &Z.Cmd{
 
 	Name:      `zet`,
 	Summary:   `zettelkasten commander`,
-	Version:   `v0.2.0`,
+	Version:   `v0.2.1`,
 	Copyright: `Copyright 2022 Daniel Michaels`,
 	License:   `Apache-2.0`,
 	Site:      `danielms.site`,

--- a/edit.go
+++ b/edit.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	Z "github.com/rwxrob/bonzai/z"
 	"github.com/rwxrob/help"
+	"github.com/rwxrob/term"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"text/template"
 )
 
@@ -122,7 +124,6 @@ func (z *Zet) openZetForEdit(zet string) error {
 }
 func (z *Zet) edit(args ...string) error {
 	zet, err := z.searchScanner(args[0])
-	println(zet)
 	fmt.Println(z)
 	err = z.openZetForEdit(zet)
 	if err != nil {
@@ -163,27 +164,18 @@ func (z *Zet) searchScanner(args ...string) (string, error) {
 	}
 	if len(ff) == 0 {
 		fmt.Printf("No entries found for %q\n", args[0])
-		return "", err
+		os.Exit(0)
 	}
 	for _, k := range ff {
 		fmt.Printf("%d) %s %s\n", k.Index, k.Id, k.Title)
 	}
-	var s int
-	fmt.Printf("#> ")
-	_, err = fmt.Scanln(&s)
-	if err != nil {
-		switch err.Error() {
-		case "unexpected newline":
-			fmt.Println("Did not enter a value. Exiting.")
-			return "", err
-		case "expected integer":
-			fmt.Println("Must enter an integer")
-			return "", err
-		default:
-			return "", err
-		}
+	prompt := term.Prompt("#> ")
+	if prompt == "" {
+		fmt.Println("exiting. did not provide valid entry.")
+		os.Exit(0)
 	}
 
+	s, _ := strconv.Atoi(prompt)
 	var zet string
 	for _, k := range ff {
 		if s == k.Index {
@@ -192,7 +184,7 @@ func (z *Zet) searchScanner(args ...string) (string, error) {
 	}
 	if zet == "" {
 		fmt.Println("Key entered does not match, or zet could not be found")
-		return "", nil
+		os.Exit(0)
 	}
 
 	return zet, nil

--- a/git.go
+++ b/git.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	Z "github.com/rwxrob/bonzai/z"
 	"github.com/rwxrob/help"
+	"github.com/rwxrob/term"
 	"os"
-	"strings"
 )
 
 var GitCmd = &Z.Cmd{
@@ -38,24 +38,11 @@ var gitPull = &Z.Cmd{
 // scanAndCommit checks that the user wants to commit their work to the VCS
 // and pushes the commit if they accept.
 func (z *Zet) scanAndCommit(zet string) error {
-	var r string
-	fmt.Printf("Commit? y/N ")
-	_, err := fmt.Scanln(&r)
-	if err != nil {
-		// <Enter> will return the following error, so we mark it as "N".
-		if err.Error() != "unexpected newline" {
-			return err
-		}
-		r = "N"
-	}
-	r = strings.TrimSpace(r)
-	r = strings.ToLower(r)
-
-	if r != "y" {
+	if term.Prompt("Commit? (y/N) ") != "y" {
 		fmt.Printf("%q not commited but modified\n", zet)
-		return nil
+		os.Exit(0)
 	}
-	err = z.PullAddCommitPush()
+	err := z.PullAddCommitPush()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR fixes several bugs with the `zet edit <search-tgt>` functionality.

See issue #23 for more detail.

The custom scanner is also replaced with `term.Prompt` which comes with Bonzai already. 

fixes #23