### PR TITLE
Fix zet commit

### DIFF
--- a/edit.go
+++ b/edit.go
@@ -124,7 +124,6 @@ func (z *Zet) openZetForEdit(zet string) error {
 }
 func (z *Zet) edit(args ...string) error {
 	zet, err := z.searchScanner(args[0])
-	fmt.Println(z)
 	err = z.openZetForEdit(zet)
 	if err != nil {
 		return err

--- a/git.go
+++ b/git.go
@@ -6,7 +6,6 @@ import (
 	Z "github.com/rwxrob/bonzai/z"
 	"github.com/rwxrob/help"
 	"github.com/rwxrob/term"
-	"log"
 	"os"
 )
 
@@ -80,7 +79,6 @@ func (z *Zet) PullAddCommitPush() error {
 
 // GitRemote checks for the existence of a non-empty `git remote -v` response.
 func (z *Zet) GitRemote() error {
-	log.Printf("git remote: %q", os.Getenv("GIT_REMOTE"))
 	if os.Getenv("GIT_REMOTE") != "" {
 		return nil
 	}

--- a/git.go
+++ b/git.go
@@ -6,6 +6,7 @@ import (
 	Z "github.com/rwxrob/bonzai/z"
 	"github.com/rwxrob/help"
 	"github.com/rwxrob/term"
+	"log"
 	"os"
 )
 
@@ -64,21 +65,22 @@ func (z *Zet) PullAddCommitPush() error {
 	}
 	err = z.Add()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to add files to git: %w", err)
 	}
 	err = z.Commit()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to commit files to git: %w", err)
 	}
 	err = z.Push()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to push files to git: %w", err)
 	}
 	return nil
 }
 
 // GitRemote checks for the existence of a non-empty `git remote -v` response.
 func (z *Zet) GitRemote() error {
+	log.Printf("git remote: %q", os.Getenv("GIT_REMOTE"))
 	if os.Getenv("GIT_REMOTE") != "" {
 		return nil
 	}

--- a/git.go
+++ b/git.go
@@ -94,7 +94,6 @@ func (z *Zet) Pull() error {
 	if err != nil {
 		return err
 	}
-
 	err = z.GitRemote()
 	if err != nil {
 		return err
@@ -132,11 +131,11 @@ func (z *Zet) Commit() error {
 }
 
 func (z *Zet) Push() error {
-	err := z.GitRemote()
+	err := z.ChangeDir(ZetRepo)
 	if err != nil {
 		return err
 	}
-	err = z.ChangeDir(ZetRepo)
+	err = z.GitRemote()
 	if err != nil {
 		return err
 	}

--- a/git.go
+++ b/git.go
@@ -60,7 +60,7 @@ func (z *Zet) PullAddCommitPush() error {
 	}
 	err := z.Pull()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to pull from git remote: %w", err)
 	}
 	err = z.Add()
 	if err != nil {

--- a/git.go
+++ b/git.go
@@ -90,11 +90,12 @@ func (z *Zet) GitRemote() error {
 }
 
 func (z *Zet) Pull() error {
-	err := z.GitRemote()
+	err := z.ChangeDir(ZetRepo)
 	if err != nil {
 		return err
 	}
-	err = z.ChangeDir(ZetRepo)
+
+	err = z.GitRemote()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`zet create 'foo'` would occasionally fail with `no git remote`.

This patch appears to fix the issue by changing where `zet` does it's `git remote` checking. 