### PR TITLE
Refactor zet edit and search functions, upgrade dependencies

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -14,7 +14,7 @@ var Cmd = &Z.Cmd{
 
 	Name:      `zet`,
 	Summary:   `zettelkasten commander`,
-	Version:   `v0.4.0`,
+	Version:   `v0.5.0`,
 	Copyright: `Copyright 2022-2024 Daniel Michaels`,
 	License:   `Apache-2.0`,
 	Site:      `danielms.site`,

--- a/edit.go
+++ b/edit.go
@@ -123,38 +123,38 @@ func (z *Zet) openZetForEdit(zet string) error {
 	return nil
 }
 func (z *Zet) edit(args ...string) error {
-	zet, err := z.searchScanner(args[0])
+	err := z.searchScanner(args[0])
 	if err != nil {
 		return err
 	}
-	err = z.openZetForEdit(zet)
+	err = z.openZetForEdit(z.Path)
 	if err != nil {
 		return err
 	}
-	err = z.scanAndCommit(zet)
+	err = z.scanAndCommit(z.Path)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (z *Zet) searchScanner(args ...string) (string, error) {
+func (z *Zet) searchScanner(args ...string) error {
 	err := z.ChangeDir(ZetRepo)
 	if err != nil {
-		return "", err
+		return err
 	}
 	dir, _ := os.Getwd()
 	files, err := z.ReadDir(dir)
 	if err != nil {
-		return "", err
+		return err
 	}
 	titles, err := z.FindTitles(files)
 	if err != nil {
-		return "", err
+		return err
 	}
 	results, err := z.SearchTitles(args[0], titles)
 	if err != nil {
-		return "", err
+		return err
 	}
 	var ff []Found
 	for idx, v := range results {
@@ -182,12 +182,13 @@ func (z *Zet) searchScanner(args ...string) (string, error) {
 	for _, k := range ff {
 		if s == k.Index {
 			zet = k.Id
+			z.Path = k.Id
+			z.Title = k.Title
 		}
 	}
 	if zet == "" {
 		fmt.Println("Key entered does not match, or zet could not be found")
 		os.Exit(0)
 	}
-
-	return zet, nil
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,11 @@ module github.com/danielmichaels/zet-cmd
 go 1.18
 
 require (
+	github.com/charmbracelet/glamour v0.5.0
 	github.com/rwxrob/bonzai v0.12.2
 	github.com/rwxrob/conf v0.6.3
 	github.com/rwxrob/help v0.4.2
+	github.com/rwxrob/term v0.2.6
 	github.com/rwxrob/vars v0.3.2
 )
 
@@ -13,7 +15,6 @@ require (
 	github.com/a8m/envsubst v1.3.0 // indirect
 	github.com/alecthomas/chroma v0.10.0 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
-	github.com/charmbracelet/glamour v0.5.0 // indirect
 	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/elliotchance/orderedmap v1.4.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
@@ -37,7 +38,6 @@ require (
 	github.com/rwxrob/fs v0.5.1 // indirect
 	github.com/rwxrob/scan v0.6.1 // indirect
 	github.com/rwxrob/structs v0.6.0 // indirect
-	github.com/rwxrob/term v0.2.6 // indirect
 	github.com/rwxrob/to v0.5.2 // indirect
 	github.com/rwxrob/yq v0.2.4 // indirect
 	github.com/timtadh/data-structures v0.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/charmbracelet/glamour v0.5.0 h1:wu15ykPdB7X6chxugG/NNfDUbyyrCLV9XBalj5wdu3g=
 github.com/charmbracelet/glamour v0.5.0/go.mod h1:9ZRtG19AUIzcTm7FGLGbq3D5WKQ5UyZBbQsMQN0XIqc=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=

--- a/zet.go
+++ b/zet.go
@@ -184,13 +184,11 @@ var ViewCmd = &Z.Cmd{
 }
 
 func (z *Zet) render(arg string) error {
-	zet, err := z.searchScanner(arg)
+	err := z.searchScanner(arg)
 	if err != nil {
 		return err
 	}
-	p := z.GetReadme(filepath.Join(ZetRepo, zet))
-	println(p)
-	println(z.Path)
+	p := z.GetReadme(filepath.Join(ZetRepo, z.Path))
 	r, err := glamour.NewTermRenderer(
 		glamour.WithAutoStyle(), glamour.WithWordWrap(zetWordWrap),
 	)


### PR DESCRIPTION
Refactored the zet edit and search functions to reduce code redundancy by using 'z.Path' instead of local variables. Removed string return in search function and the usage of the variable 'zet' in the render and edit methods. Also, updated libraries to a newer version and bumped the application version to 'v0.5.0'.